### PR TITLE
Don't use __DIR__ for PHP 5.2 compatibility

### DIFF
--- a/ig-syntax-hiliter.php
+++ b/ig-syntax-hiliter.php
@@ -13,14 +13,14 @@ if( ! defined('IG_SYNTAX_HILITER_VERSION') ) {
 }
 
 //load up the plugin base abstract class
-require_once( __DIR__ . "/class-ig-syntax-hiliter.php" );
+require_once( "class-ig-syntax-hiliter.php" );
 //load up the plugin admin class
-require_once( __DIR__ . "/class-ig-syntax-hiliter-admin.php" );
+require_once( "class-ig-syntax-hiliter-admin.php" );
 //load up the plugin front-end class
-require_once( __DIR__ . "/class-ig-syntax-hiliter-frontend.php" );
+require_once( "class-ig-syntax-hiliter-frontend.php" );
 
 //load up GeSHi
-require_once( __DIR__ . "/geshi.php" );
+require_once( "geshi.php" );
 
 //set loader to execute on WP init
 add_action( 'init', 'ig_syntax_hiliter_loader' );


### PR DESCRIPTION
`__DIR__` constant is available since PHP 5.3 (http://php.net/manual/en/language.constants.predefined.php), while project's README claims compatibility with 5.2. I got tripped by this when trying to activate the plugin on my 5.2.17 server, so I made this fix to resolve it.

Feel free to propose a different solution to this problem. I'm not a PHP expert so I don't know if it won't cause problems for someone else; it works fine for me as of now.
